### PR TITLE
Fix length mismatch for openInApp array

### DIFF
--- a/goaround/ContentView.swift
+++ b/goaround/ContentView.swift
@@ -206,8 +206,12 @@ struct ContentView: View {
             openInApp = zip(webSites, decodedOpenInApp)
                 .filter { !$0.0.isEmpty }
                 .map { $0.1 }
+
+            if openInApp.count < webSites.count {
+                openInApp.append(contentsOf: Array(repeating: true, count: webSites.count - openInApp.count))
+            }
         } else {
-            openInApp = Array(repeating: true, count: 20)
+            openInApp = Array(repeating: true, count: webSites.count)
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the `openInApp` array is at least as long as the website list in `ContentView`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6878f9121548832ba76b10dc9f7f154e