### PR TITLE
Fix initial blank web view issue

### DIFF
--- a/goaround/ContentView.swift
+++ b/goaround/ContentView.swift
@@ -200,7 +200,7 @@ struct ContentView: View {
         if let decodedWebSites = try? JSONDecoder().decode([String].self, from: webSitesData) {
             webSites = decodedWebSites.filter { !$0.isEmpty }
         } else {
-            webSites = Array(repeating: "", count: Constants.maxWebSites)
+            webSites = []
         }
 
         if let decodedOpenInApp = try? JSONDecoder().decode([Bool].self, from: openInAppData) {
@@ -208,7 +208,7 @@ struct ContentView: View {
                 .filter { !$0.0.isEmpty }
                 .map { $0.1 }
         } else {
-            openInApp = Array(repeating: true, count: Constants.maxWebSites)
+            openInApp = Array(repeating: true, count: webSites.count)
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid populating blank web views when there is no stored data
- ensure `openInApp` default length matches loaded sites

## Testing
- `swiftc -parse goaround/ContentView.swift`
- `for f in goaround/*.swift; do swiftc -parse "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_687b01ff7cd4832b8bc54f88d1cbdb81